### PR TITLE
Test fully installing the extension

### DIFF
--- a/sql/test_factory.sql
+++ b/sql/test_factory.sql
@@ -1,4 +1,5 @@
 CREATE TEMP TABLE original_role ON COMMIT DROP AS SELECT current_user AS original_role;
+
 GRANT SELECT ON pg_temp.original_role TO public;
 DO $body$
 BEGIN

--- a/sql/test_factory_pgtap.sql
+++ b/sql/test_factory_pgtap.sql
@@ -35,4 +35,6 @@ BEGIN
 END
 $body$;
 
+DROP TABLE pg_temp.original_role;
+
 -- vi: expandtab ts=2 sw=2

--- a/test/deps.sql
+++ b/test/deps.sql
@@ -1,0 +1,15 @@
+-- IF NOT EXISTS will emit NOTICEs, which is annoying
+SET client_min_messages = WARNING;
+
+-- Add any test dependency statements here
+-- Note: pgTap is loaded by setup.sql
+--CREATE EXTENSION IF NOT EXISTS ...;
+/*
+ * Now load our extension. We don't use IF NOT EXISTs here because we want an
+ * error if the extension is already loaded (because we want to ensure we're
+ * getting the very latest version).
+ */
+CREATE EXTENSION ...;
+
+-- Re-enable notices
+SET client_min_messages = NOTICE;

--- a/test/helpers/tap_setup.sql
+++ b/test/helpers/tap_setup.sql
@@ -1,10 +1,14 @@
 \i test/helpers/psql.sql
 
-CREATE SCHEMA tap;
+/*
+ * NOTE: if you get errors about things already existing it's because they've
+ * been left behind by test/sql/install.sql
+ */
+SET client_min_messages = WARNING;
+CREATE SCHEMA IF NOT EXISTS tap;
 SET search_path = tap;
 CREATE EXTENSION IF NOT EXISTS pgtap SCHEMA tap;
---\i test/helpers/pgtap-core.sql
---\i test/helpers/pgtap-schema.sql
+SET client_min_messages = NOTICE;
 
 \pset format unaligned
 \pset tuples_only true

--- a/test/pgxntool
+++ b/test/pgxntool
@@ -1,0 +1,1 @@
+../pgxntool/test/pgxntool


### PR DESCRIPTION
Add a test for installing the extensions and actually committing. This matters because it's possible to have issues with the ON COMMIT DROP specification on the temp table that the extension script creates.